### PR TITLE
Strong admis fix

### DIFF
--- a/cmake/YOMM2_download.cmake.in
+++ b/cmake/YOMM2_download.cmake.in
@@ -3,7 +3,7 @@ include(ExternalProject)
 project(YOMM2)
 ExternalProject_Add(${PROJECT_NAME}
   GIT_REPOSITORY      https://github.com/jll63/yomm2.git
-  GIT_TAG             master
+  GIT_TAG             v1.3.1
   @ADDITIONAL_GIT_SETTINGS@
   SOURCE_DIR          "@CMAKE_SOURCE_DIR@/dependencies/sources/${PROJECT_NAME}"
   BINARY_DIR          "@CMAKE_CURRENT_BINARY_DIR@/${PROJECT_NAME}_build"

--- a/include/FRANK/classes/low_rank.h
+++ b/include/FRANK/classes/low_rank.h
@@ -8,6 +8,7 @@
 #define FRANK_classes_low_rank_h
 
 #include "FRANK/classes/dense.h"
+#include "FRANK/classes/hierarchical.h"
 #include "FRANK/classes/matrix.h"
 #include "FRANK/classes/matrix_proxy.h"
 
@@ -113,6 +114,8 @@ class LowRank : public Matrix {
    * #V.
    */
   LowRank(const Dense& A, const int64_t rank);
+
+  LowRank(const Hierarchical& A, const int64_t rank);
 
   /**
    * @brief Construct a new `LowRank` object by compressing a `Dense` matrix

--- a/include/FRANK/operations/randomized_factorizations.h
+++ b/include/FRANK/operations/randomized_factorizations.h
@@ -13,6 +13,7 @@ namespace FRANK
 {
 
 class Dense;
+class Hierarchical;
 
 /**
  * @brief Compute randomized one-sided interpolatory decomposition (ID) of a `Dense` matrix
@@ -108,6 +109,8 @@ std::tuple<Dense, Dense, Dense> rid(
  * The SVD is the given by \f$A [M x N] \approx U [M x sample_size] D [sample_size x sample_size] V^T [sample_size x N]\f$.
  */
 std::tuple<Dense, Dense, Dense> rsvd(const Dense& A, const int64_t sample_size);
+
+std::tuple<Dense, Dense, Dense> rsvd(const Hierarchical& A, const int64_t sample_size);
 
 /**
  * @brief Calculates a randomized singular value decomposition (SVD) of a `Dense` matrix.

--- a/src/classes/low_rank.cpp
+++ b/src/classes/low_rank.cpp
@@ -47,6 +47,16 @@ LowRank::LowRank(const Dense& A, const int64_t rank)
   S = resize(S, rank, rank);
 }
 
+LowRank::LowRank(const Hierarchical& A, const int64_t rank)
+: Matrix(A), dim{A.dim[0], A.dim[1]}, rank(rank) {
+  // Rank with oversampling limited by dimensions
+  std::tie(U, S, V) = rsvd(A, std::min(std::min(rank+5, dim[0]), dim[1]));
+  // Reduce to actual desired rank
+  U = resize(U, dim[0], rank);
+  V = resize(V, rank, dim[1]);
+  S = resize(S, rank, rank);
+}
+
 LowRank::LowRank(const Dense& A, const double eps)
 : Matrix(A), dim{A.dim[0], A.dim[1]}, eps(eps) {
   Dense R;

--- a/src/operations/BLAS/gemm.cpp
+++ b/src/operations/BLAS/gemm.cpp
@@ -120,7 +120,7 @@ define_method(
     TransB ? get_n_rows(B) : get_n_cols(B)
   );
   gemm(A, B, C, alpha, 0, TransA, TransB);
-  return C;
+  return std::move(C);
 }
 
 define_method(

--- a/src/operations/BLAS/gemm.cpp
+++ b/src/operations/BLAS/gemm.cpp
@@ -402,20 +402,19 @@ define_method(
   )
 ) {
   // H H LR
-  /*
-    Making a Hierarchical out of C might be better
-    But LowRank(Hierarchical, rank) constructor is needed
-      Hierarchical CH(C);
-      gemm(A, B, CH, alpha, beta);
-      C = LowRank(CH, rank);
-  */
-  Dense CD(C);
-  gemm(A, B, CD, alpha, beta, TransA, TransB);
+  
   const bool use_eps = (C.eps != 0.0);
-  if(use_eps)
+  if(use_eps){
+    //not optimized for fixed error yet
+    Dense CD(C);
+    gemm(A, B, CD, alpha, beta, TransA, TransB);
     C = LowRank(CD, C.eps);
-  else
-    C = LowRank(CD, C.rank);
+  } else {
+    Hierarchical AB = gemm(A, B, alpha, TransA, TransB);
+    LowRank D(AB, C.rank);
+    C.S *= beta;
+    C += D;
+  }
 }
 
 define_method(

--- a/src/operations/BLAS/gemm.cpp
+++ b/src/operations/BLAS/gemm.cpp
@@ -603,25 +603,7 @@ define_method(
   // LR H D
   if (B.dim[0] == 1 && B.dim[1] == 1) {
     gemm(A, B(0, 0), C, alpha, beta, TransA, TransB);
-  }
-  /*else if (B.dim[TransB ? 1 : 0] == 1) {
-    Hierarchical CH = split(C, 1, B.dim[TransB ? 0 : 1]);
-    gemm(A, B, CH, alpha, beta, TransA, TransB);
-  }
-  else if (B.dim[TransB ? 0 : 1] == 1) {
-    const Hierarchical AH = split(
-      A,
-      TransA ? B.dim[TransB ? 1 : 0] : 1,
-      TransA ? 1 : B.dim[TransB ? 1 : 0]
-    );
-    gemm(AH, B, C, alpha, beta, TransA, TransB);
-  }*/
-  else {
-    /*const Hierarchical AH = split(
-      A,
-      TransA ? B.dim[TransB ? 1 : 0] : 1,
-      TransA ? 1 : B.dim[TransB ? 1 : 0]
-    );*/
+  } else {
     Hierarchical CH = split(C, 1, B.dim[TransB ? 0 : 1]);
     gemm(A, B, CH, alpha, beta, TransA, TransB);
   }
@@ -639,25 +621,7 @@ define_method(
   // H LR D
   if (A.dim[0] == 1 && A.dim[1] == 1) {
     gemm(A(0, 0), B, C, alpha, beta, TransA, TransB);
-  }
-  /*else if (A.dim[TransA ? 0 : 1] == 1) {
-    Hierarchical CH = split(C, A.dim[TransA ? 1 : 0], 1);
-    gemm(A, B, CH, alpha, beta, TransA, TransB);
-  }
-  else if (A.dim[TransA ? 1 : 0] == 1) {
-    const Hierarchical BH = split(
-      B,
-      TransB ? 1 : A.dim[TransA ? 0 : 1],
-      TransB ? A.dim[TransA ? 0 : 1] : 1
-    );
-    gemm(A, BH, C, alpha, beta, TransA, TransB);
-  }*/
-  else {
-    /*const Hierarchical BH = split(
-      B,
-      TransB ? 1 : A.dim[TransA ? 0 : 1],
-      TransB ? A.dim[TransA ? 0 : 1] : 1
-    );*/
+  } else {
     Hierarchical CH = split(C, A.dim[TransA ? 1 : 0], 1);
     gemm(A, B, CH, alpha, beta, TransA, TransB);
   }

--- a/src/operations/BLAS/gemm.cpp
+++ b/src/operations/BLAS/gemm.cpp
@@ -210,10 +210,11 @@ define_method(
   // D D LR
   C.S *= beta;
   const bool use_eps = (C.eps != 0.0);
+  Dense AB = gemm(A, B, alpha, TransA, TransB);
   if(use_eps)
-    C += LowRank(gemm(A, B, alpha, TransA, TransB), C.eps);
+    C += LowRank(AB, C.eps);
   else
-    C += LowRank(gemm(A, B, alpha, TransA, TransB), C.rank);
+    C += LowRank(AB, C.rank);
 }
 
 define_method(

--- a/src/operations/LAPACK/mgs_qr.cpp
+++ b/src/operations/LAPACK/mgs_qr.cpp
@@ -96,7 +96,7 @@ define_method(
     storage(currentRow, i) = splitted(0, i);
   }
   currentRow++;
-  return U;
+  return std::move(U);
 }
 
 define_method(
@@ -150,7 +150,7 @@ define_method(
   assert(A.dim[0] == concatenatedRow.dim[0]);
   assert(A.dim[1] == concatenatedRow.dim[1]);
   currentRow++;
-  return concatenatedRow;
+  return std::move(concatenatedRow);
 }
 
 define_method(
@@ -174,7 +174,7 @@ define_method(
   LowRank _A(Dense(Q), Dense(identity, {}, _rank, _rank), concatenatedRow);
   _A.eps = A.eps;
   currentRow++;
-  return _A;
+  return std::move(_A);
 }
 
 define_method(
@@ -193,7 +193,7 @@ define_method(
     }
     currentRow++;
   }
-  return concatenatedRow;
+  return std::move(concatenatedRow);
 }
 
 define_method(

--- a/src/operations/arithmetic/subtraction.cpp
+++ b/src/operations/arithmetic/subtraction.cpp
@@ -12,6 +12,7 @@ using yorel::yomm2::virtual_;
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
+#include <utility>
 
 
 namespace FRANK
@@ -35,7 +36,7 @@ define_method(MatrixProxy, subtraction_omm, (const Dense& A, const Dense& B)) {
       out(i, j) = A(i, j) - B(i, j);
     }
   }
-  return out;
+  return std::move(out);
 }
 
 define_method(

--- a/src/operations/misc/misc.cpp
+++ b/src/operations/misc/misc.cpp
@@ -19,6 +19,7 @@ using yorel::yomm2::virtual_;
 #include <cstdlib>
 #include <numeric>
 #include <vector>
+#include <utility>
 
 
 namespace FRANK
@@ -296,7 +297,7 @@ define_method(MatrixProxy, shallow_copy_omm, (const Dense& A)) {
 define_method(MatrixProxy, shallow_copy_omm, (const LowRank& A)) {
   LowRank scopy(A.U, A.S, A.V, false);
   scopy.eps = A.eps;
-  return scopy;
+  return std::move(scopy);
 }
 
 define_method(MatrixProxy, shallow_copy_omm, (const Hierarchical& A)) {
@@ -306,7 +307,7 @@ define_method(MatrixProxy, shallow_copy_omm, (const Hierarchical& A)) {
       new_shallow_copy(i, j) = shallow_copy(A(i, j));
     }
   }
-  return new_shallow_copy;
+  return std::move(new_shallow_copy);
 }
 
 define_method(MatrixProxy, shallow_copy_omm, (const Matrix& A)) {

--- a/src/operations/misc/resize.cpp
+++ b/src/operations/misc/resize.cpp
@@ -10,6 +10,7 @@ using yorel::yomm2::virtual_;
 
 #include <cassert>
 #include <cstdint>
+#include <utility>
 
 
 namespace FRANK
@@ -30,7 +31,7 @@ define_method(
   assert(n_cols <= A.dim[1]);
   Dense resized(n_rows, n_cols);
   A.copy_to(resized);
-  return resized;
+  return std::move(resized);
 }
 
 define_method(MatrixProxy, resize_omm, (const Matrix& A, const int64_t, const int64_t)) {

--- a/src/operations/misc/transpose.cpp
+++ b/src/operations/misc/transpose.cpp
@@ -11,6 +11,7 @@
 using yorel::yomm2::virtual_;
 
 #include <cstdint>
+#include <utility>
 
 
 namespace FRANK
@@ -27,12 +28,12 @@ define_method(MatrixProxy, transpose_omm, (const Dense& A)) {
       transposed(j,i) = A(i,j);
     }
   }
-  return transposed;
+  return std::move(transposed);
 }
 
 define_method(MatrixProxy, transpose_omm, (const LowRank& A)) {
   LowRank transposed(transpose(A.V), transpose(A.S), transpose(A.U));
-  return transposed;
+  return std::move(transposed);
 }
 
 define_method(MatrixProxy, transpose_omm, (const Hierarchical& A)) {
@@ -42,7 +43,7 @@ define_method(MatrixProxy, transpose_omm, (const Hierarchical& A)) {
       transposed(j, i) = transpose(A(i, j));
     }
   }
-  return transposed;
+  return std::move(transposed);
 }
 
 define_method(MatrixProxy, transpose_omm, (const Matrix& A)) {


### PR DESCRIPTION
Seems like the cmake integration does not work with the newest version of YOMM.
Therefore fixed the YOMM version to the last known working release (v1.3.1).

Also integrated fixes for strong admissibility that prevent LR blocks from being split up repeatedly.